### PR TITLE
Fixes #2 and Fixes #1 Uninstall failures

### DIFF
--- a/menu_attributes.install
+++ b/menu_attributes.install
@@ -22,7 +22,6 @@ function menu_attributes_install() {
  * Implements hook_uninstall().
  */
 function menu_attributes_uninstall() {
-  backdrop_load('module', 'menu_attributes');
   $config = config('menu_attributes');
   $config->delete();
 }

--- a/menu_attributes.install
+++ b/menu_attributes.install
@@ -22,7 +22,7 @@ function menu_attributes_install() {
  * Implements hook_uninstall().
  */
 function menu_attributes_uninstall() {
-  drupal_load('module', 'menu_attributes');
+  backdrop_load('module', 'menu_attributes');
   $attributes = menu_attributes_menu_attribute_info();
   foreach (array_keys($attributes) as $attribute) {
     config_clear("menu_attributes_{$attribute}_enable");

--- a/menu_attributes.install
+++ b/menu_attributes.install
@@ -23,11 +23,8 @@ function menu_attributes_install() {
  */
 function menu_attributes_uninstall() {
   backdrop_load('module', 'menu_attributes');
-  $attributes = menu_attributes_menu_attribute_info();
-  foreach (array_keys($attributes) as $attribute) {
-    config_clear("menu_attributes_{$attribute}_enable");
-    config_clear("menu_attributes_{$attribute}_default");
-  }
+  $config = config('menu_attributes');
+  $config->delete();
 }
 
 /**


### PR DESCRIPTION
Fixes #2 
Replaced call to drupal_load with call to backdrop_load on line 25

Fixes #1 
Replaces iterative calls to clear attributes (which misses some) with deleting the config entirely.
In hindsight, after making the change above, realised that backdrop_load is not required so removed this altogether.
