### PR TITLE
Issue #8: Remove deprecated default value usage for PHP 8.

### DIFF
--- a/menu_attributes.module
+++ b/menu_attributes.module
@@ -193,7 +193,7 @@ function menu_attributes_form_node_form_alter(&$form, $form_state) {
  * @param $item
  *   The optional existing menu item for context.
  */
-function _menu_attributes_form_alter(array &$form, array $item = array(), array &$complete_form) {
+function _menu_attributes_form_alter(array &$form, array $item, array &$complete_form) {
   $form['options']['#tree'] = TRUE;
   $form['options']['#weight'] = 50;
 


### PR DESCRIPTION
Fixes https://github.com/backdrop-contrib/menu_attributes/issues/6.